### PR TITLE
Add comment on how to execute create_training_data.py on Mac

### DIFF
--- a/create_training_data.py
+++ b/create_training_data.py
@@ -1,3 +1,5 @@
+# This file or any other file executing the getkeys.py must be executed on terminal as the root user, i.e. sudo python create_training_data.py
+
 # create_training_data.py
 
 import numpy as np


### PR DESCRIPTION
Mac OS restrains the script to normally read keyboard inputs if not run as root. If such a warning is not present, people who are unaware of this fact will not be able to decipher why the code isn't working.